### PR TITLE
Workflow: Support pushing images in PR's, support canary tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,12 @@
 name: build
 
+env:
+  IMAGE: archiving
+
 on:
+  # Careful: Chaning any of the triggers may
+  # lead to image pushed on unwanted branches,
+  # see the branch-based event usages below!
   push:
     branches: [ main ]
   pull_request:
@@ -17,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      TAG: ${{ github.event.release.tag_name }}
+      TAG: canary
 
     steps:
 
@@ -25,46 +31,48 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
-      - name: Set tag for non-release builds
-        if: github.event_name != 'release'
+      - name: Set tag for non-main-branch builds
         run: |
-          echo "TAG=${{ github.sha }}" >> $GITHUB_ENV
+          if [[ "${{ github.event_name }}" == "release" ]]; then
+            echo "TAG=${{ github.event.release.tag_name }}" >> $GITHUB_ENV
+          elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "TAG=pr${{github.event.number}}" >> $GITHUB_ENV
+          fi
 
       - name: Login to GitHub Container Registry
-        # don't even login to GitHub CR if this is not a release
-        if: github.event_name == 'release'
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build / Release
-        uses: docker/build-push-action@v2
+      - name: Build
+        uses: docker/build-push-action@v3
         with:
-          # push and load may not be set together at the moment
-          load: ${{ github.event_name != 'release' }}
-          push: ${{ github.event_name == 'release' }}
-          tags: |
-            ghcr.io/${{ github.repository_owner }}/archiving:latest
-            ghcr.io/${{ github.repository_owner }}/archiving:${{ env.TAG }}
+          load: true
+          tags: ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE }}:${{ env.TAG }}
 
-      - name: Run Version
-        # as push and load may not be set together at the moment
-        # we can only run this step in non-release builds
-        if: github.event_name != 'release'
+      - name: Push
         run: |
-          docker run ghcr.io/${{ github.repository_owner }}/archiving:latest /opt/bitnami/apache/bin/apachectl -v ;\
-          docker run ghcr.io/${{ github.repository_owner }}/archiving:latest ls -al /opt/bitnami/apache/modules/mod_auth_mellon.so
+          docker push ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE }}:${{ env.TAG }}
+
+      - name: Push latest
+        if: github.event_name == 'release'
+        run: |
+          docker tag  ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE }}:${{ env.TAG }} \
+                      ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE }}:latest
+          docker push ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE }}:latest
+
+      - name: Run version
+        run: |
+          docker run ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE }}:${{ env.TAG }} /opt/bitnami/apache/bin/apachectl -v ;\
+          docker run ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE }}:${{ env.TAG }} ls -al /opt/bitnami/apache/modules/mod_auth_mellon.so
 
       - name: Inspect
-        # as push and load may not be set together at the moment
-        # we can only run this step in non-release builds
-        if: github.event_name != 'release'
         run: |
-          docker image inspect ghcr.io/${{ github.repository_owner }}/archiving:latest
+          docker image inspect ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE }}:${{ env.TAG }}


### PR DESCRIPTION
With this change it's no longer necessary to bring test code onto the
main branch and to create releases of images that not actually are
releases.

In PR's the workflow now also publishes images tagged with the PR
version number, e.g. user/image:pr123.

Also, every change that gets merged to the main branch will be tagged
with the 'canary' tag. The 'latest' tags are only used for releases.