### PR TITLE
Provide custom scripts for watching configs, install inotify-tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,4 +34,12 @@ RUN wget "https://github.com/latchset/mod_auth_mellon/releases/download/v${MOD_A
     make install && \
     rm -rf /tmp/mod_auth_mellon*
 
+# install generic packages (keep separated in case we want to use builder image)
+RUN apt-get update && apt-get install -y \
+        inotify-tools \
+    && rm -rf /var/lib/apt/lists/*
+
+# add (and override) scripts to scripts in upstream image
+COPY ./scripts /opt/bitnami/scripts/apache/
+
 USER www-data

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# shellcheck disable=SC1091
+
+set -o errexit
+set -o nounset
+set -o pipefail
+# set -o xtrace # Uncomment this line for debugging purposes
+
+# Load libraries
+. /opt/bitnami/scripts/libapache.sh
+. /opt/bitnami/scripts/liblog.sh
+
+# Load Apache environment
+. /opt/bitnami/scripts/apache-env.sh
+
+# Watch for changes in the conf directory
+info "** Starting Apache config watcher **"
+/opt/bitnami/scripts/apache/watch-config.sh &
+info "** Apache config watcher started in background! **"
+
+info "** Starting Apache **"
+exec "${APACHE_BIN_DIR}/httpd" -f "$APACHE_CONF_FILE" -D "FOREGROUND"

--- a/scripts/watch-config.sh
+++ b/scripts/watch-config.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Load libraries
+. /opt/bitnami/scripts/libapache.sh
+. /opt/bitnami/scripts/libbitnami.sh
+. /opt/bitnami/scripts/liblog.sh
+
+# Load Apache environment
+. /opt/bitnami/scripts/apache-env.sh
+
+mkdir -p conf
+
+while inotifywait -e create,delete,modify,move -r conf; do
+    /opt/bitnami/scripts/apache/reload.sh;
+done


### PR DESCRIPTION
In order to be able to automatically reload the Apache webserver gracefully when Apache config changes, a custom script for watching the config has been provided. This script is now started as a background process by a modified run script. Like this, the config watcher automatically gets started everytime the Apache webserver gets started too.

As the config watcher is based on the inotifywait command, the package inotify-tools has been installed in the container.